### PR TITLE
Add documentation to tables and procedures

### DIFF
--- a/schema/350$alert.deliveryChannel.sql
+++ b/schema/350$alert.deliveryChannel.sql
@@ -1,6 +1,6 @@
-CREATE TABLE [alert].[deliveryChannel] (
-    [id] int IDENTITY(1,1) not null,
-	[name] nvarchar(255) not null,
+CREATE TABLE [alert].[deliveryChannel] ( -- List of supported deliver channels by ut-alert module
+    [id] int IDENTITY(1,1) not null, -- The PK of the channel
+	[name] nvarchar(255) not null, -- Unique name of the channel
 	CONSTRAINT [pk_alert_deliveryChannel_id] PRIMARY KEY CLUSTERED ([id]),
 	CONSTRAINT [uq_alert_deliveryChannel_name] UNIQUE ([name])
 )

--- a/schema/350$alert.deliveryChannel.sql
+++ b/schema/350$alert.deliveryChannel.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [alert].[deliveryChannel] ( -- List of supported deliver channels by ut-alert module
     [id] int IDENTITY(1,1) not null, -- The PK of the channel
-	[name] nvarchar(255) not null, -- Unique name of the channel
-	CONSTRAINT [pk_alert_deliveryChannel_id] PRIMARY KEY CLUSTERED ([id]),
-	CONSTRAINT [uq_alert_deliveryChannel_name] UNIQUE ([name])
+    [name] nvarchar(255) not null, -- Unique name of the channel
+    CONSTRAINT [pk_alert_deliveryChannel_id] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [uq_alert_deliveryChannel_name] UNIQUE ([name])
 )

--- a/schema/350$alert.status.sql
+++ b/schema/350$alert.status.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [alert].[status] ( -- table that stores the statuses of the meassages
     [id] tinyint IDENTITY(1,1) not null, -- the PK of the status
-	[name] nvarchar(64) not null, -- the name of the status
-	CONSTRAINT [pk_alert_status_id] PRIMARY KEY CLUSTERED ([id]),
-	CONSTRAINT [uq_alert_status_name] UNIQUE ([name])
+    [name] nvarchar(64) not null, -- the name of the status
+    CONSTRAINT [pk_alert_status_id] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [uq_alert_status_name] UNIQUE ([name])
 )

--- a/schema/351$alert.deliveryChannelItemType.sql
+++ b/schema/351$alert.deliveryChannelItemType.sql
@@ -1,7 +1,7 @@
 CREATE TABLE [alert].[deliveryChannelItemType] ( -- Connects a channel to one or more item (translatable templates) types in the core module.
-	[channelId] int not null, -- References to channel
-	[itemTypeId] int not null, -- Reference to item type
-	CONSTRAINT [ph_alert_deliveryChannel_channelId_itemTypeId] PRIMARY KEY CLUSTERED ([channelId], [itemTypeId]),
-	CONSTRAINT [fk_alert_deliveryChannelItemType_channelId_alert_deliveryChannel_id] FOREIGN KEY ([channelId]) REFERENCES [alert].[deliveryChannel] ([id]),
-	CONSTRAINT [fk_alert_deliveryChannelItemType_itemTypeId_core_itemType_id] FOREIGN KEY ([itemTypeId]) REFERENCES [core].[itemType] ([itemTypeId])
+    [channelId] int not null, -- References to channel
+    [itemTypeId] int not null, -- Reference to item type
+    CONSTRAINT [ph_alert_deliveryChannel_channelId_itemTypeId] PRIMARY KEY CLUSTERED ([channelId], [itemTypeId]),
+    CONSTRAINT [fk_alert_deliveryChannelItemType_channelId_alert_deliveryChannel_id] FOREIGN KEY ([channelId]) REFERENCES [alert].[deliveryChannel] ([id]),
+    CONSTRAINT [fk_alert_deliveryChannelItemType_itemTypeId_core_itemType_id] FOREIGN KEY ([itemTypeId]) REFERENCES [core].[itemType] ([itemTypeId])
 )

--- a/schema/351$alert.deliveryChannelItemType.sql
+++ b/schema/351$alert.deliveryChannelItemType.sql
@@ -1,6 +1,6 @@
-CREATE TABLE [alert].[deliveryChannelItemType] (
-	[channelId] int not null,
-	[itemTypeId] int not null,
+CREATE TABLE [alert].[deliveryChannelItemType] ( -- Connects a channel to one or more item (translatable templates) types in the core module.
+	[channelId] int not null, -- References to channel
+	[itemTypeId] int not null, -- Reference to item type
 	CONSTRAINT [ph_alert_deliveryChannel_channelId_itemTypeId] PRIMARY KEY CLUSTERED ([channelId], [itemTypeId]),
 	CONSTRAINT [fk_alert_deliveryChannelItemType_channelId_alert_deliveryChannel_id] FOREIGN KEY ([channelId]) REFERENCES [alert].[deliveryChannel] ([id]),
 	CONSTRAINT [fk_alert_deliveryChannelItemType_itemTypeId_core_itemType_id] FOREIGN KEY ([itemTypeId]) REFERENCES [core].[itemType] ([itemTypeId])

--- a/schema/360$alert.messageQueue.sql
+++ b/schema/360$alert.messageQueue.sql
@@ -8,7 +8,7 @@ CREATE TABLE [alert].[messageQueue] ( -- table that stores all the messages that
     [createdOn] datetimeoffset not null, -- when the message is created    
     [statusId] tinyint not null, -- the status of the message
     [priority] smallint not null, -- the priority of the message
-	CONSTRAINT [pk_messageQueue_id] PRIMARY KEY CLUSTERED ([id]),
-	CONSTRAINT [fk_alert_message_statusId_alert_status_id] FOREIGN KEY ([statusId]) REFERENCES [alert].[status] ([id]),
-	CONSTRAINT [fk_alert_message_createdBy_core_actor_id] FOREIGN KEY ([createdBy]) REFERENCES [core].[actor] ([actorId])
+    CONSTRAINT [pk_messageQueue_id] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [fk_alert_message_statusId_alert_status_id] FOREIGN KEY ([statusId]) REFERENCES [alert].[status] ([id]),
+    CONSTRAINT [fk_alert_message_createdBy_core_actor_id] FOREIGN KEY ([createdBy]) REFERENCES [core].[actor] ([actorId])
 )

--- a/schema/750$alert.queue.notifyFailure.sql
+++ b/schema/750$alert.queue.notifyFailure.sql
@@ -26,5 +26,5 @@ BEGIN TRY
     WHERE m.[id] = @messageId;
 END TRY
 BEGIN CATCH
-	exec core.error
+	EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.notifyFailure.sql
+++ b/schema/750$alert.queue.notifyFailure.sql
@@ -26,5 +26,5 @@ BEGIN TRY
     WHERE m.[id] = @messageId;
 END TRY
 BEGIN CATCH
-	EXEC core.error
+    EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.notifySuccess.sql
+++ b/schema/750$alert.queue.notifySuccess.sql
@@ -24,5 +24,5 @@ BEGIN TRY
     WHERE m.[id] = @messageId;
 END TRY
 BEGIN CATCH
-	exec core.error
+	EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.notifySuccess.sql
+++ b/schema/750$alert.queue.notifySuccess.sql
@@ -24,5 +24,5 @@ BEGIN TRY
     WHERE m.[id] = @messageId;
 END TRY
 BEGIN CATCH
-	EXEC core.error
+    EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.pop.sql
+++ b/schema/750$alert.queue.pop.sql
@@ -21,5 +21,5 @@ BEGIN TRY
     JOIN [alert].[messageQueue] m on s.Id = m.id
 END TRY
 BEGIN CATCH
-	EXEC core.error
+    EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.pop.sql
+++ b/schema/750$alert.queue.pop.sql
@@ -21,5 +21,5 @@ BEGIN TRY
     JOIN [alert].[messageQueue] m on s.Id = m.id
 END TRY
 BEGIN CATCH
-	exec core.error
+	EXEC core.error
 END CATCH

--- a/schema/750$alert.queue.push.sql
+++ b/schema/750$alert.queue.push.sql
@@ -1,29 +1,29 @@
 ALTER PROCEDURE [alert].[queue.push]
-	@port varchar(255),
+    @port varchar(255),
     @channel varchar(128),
-	@recipient [core].[arrayList] READONLY,
-	@content nvarchar(max),
-	@priority int = 0,
-	@meta [core].[metaDataTT] READONLY
+    @recipient [core].[arrayList] READONLY,
+    @content nvarchar(max),
+    @priority int = 0,
+    @meta [core].[metaDataTT] READONLY
 AS
 BEGIN
-	BEGIN TRY
-		DECLARE @statusName nvarchar(255) = 'QUEUED'
+    BEGIN TRY
+        DECLARE @statusName nvarchar(255) = 'QUEUED'
         DECLARE @statusId int = (select id from [alert].[status] where name = @statusName)
-		DECLARE @actorId bigint = (select [auth.actorId] from @meta)
+        DECLARE @actorId bigint = (select [auth.actorId] from @meta)
 
-		IF @actorId IS NULL
-			RAISERROR(N'alert.systemMessage.add.missingCreatorId', 16, 1);
+        IF @actorId IS NULL
+            RAISERROR(N'alert.systemMessage.add.missingCreatorId', 16, 1);
 
         SELECT 'inserted' resultSetName;
 
-		INSERT INTO [alert].[messageQueue](port, channel, recipient, content, createdBy, createdOn, statusId, priority)
-		OUTPUT INSERTED.id, INSERTED.port, INSERTED.channel, INSERTED.recipient, INSERTED.content, INSERTED.createdBy, INSERTED.createdOn,
+        INSERT INTO [alert].[messageQueue](port, channel, recipient, content, createdBy, createdOn, statusId, priority)
+        OUTPUT INSERTED.id, INSERTED.port, INSERTED.channel, INSERTED.recipient, INSERTED.content, INSERTED.createdBy, INSERTED.createdOn,
                 @statusName as status, INSERTED.priority
         SELECT @port, @channel, LTRIM(RTRIM([value])), @content, @actorId, SYSDATETIMEOFFSET(), @statusId, @priority
         FROM @recipient
-	END TRY
-	BEGIN CATCH
-		 EXEC [core].[error]
-	END CATCH
+    END TRY
+    BEGIN CATCH
+         EXEC [core].[error]
+    END CATCH
 END

--- a/schema/750$alert.template.fetch.sql
+++ b/schema/750$alert.template.fetch.sql
@@ -20,5 +20,5 @@ BEGIN TRY
     JOIN [core].[language] l ON it.languageId = l.languageId AND l.iso2Code = @languageCode;
 END TRY
 BEGIN CATCH
-	exec core.error
+	EXEC core.error
 END CATCH

--- a/schema/750$alert.template.fetch.sql
+++ b/schema/750$alert.template.fetch.sql
@@ -20,5 +20,5 @@ BEGIN TRY
     JOIN [core].[language] l ON it.languageId = l.languageId AND l.iso2Code = @languageCode;
 END TRY
 BEGIN CATCH
-	EXEC core.error
+    EXEC core.error
 END CATCH


### PR DESCRIPTION
Tables and procedures must have documentation. Additionally change indentation from tabs to 4 spaces.
