### PR TITLE
Fix the alert module to work with history triggers

### DIFF
--- a/schema/750$alert.queueIn.pop.sql
+++ b/schema/750$alert.queueIn.pop.sql
@@ -16,7 +16,7 @@ BEGIN TRY
     UPDATE m
     SET [statusId] =  @statusProcessing
     OUTPUT INSERTED.id, INSERTED.port, INSERTED.channel, INSERTED.sender, INSERTED.content
-    INTO #messageIn ()
+    INTO #messageIn (id, port, channel, sender, content)
     FROM
     (
         SELECT TOP 1 [id]

--- a/schema/750$alert.queueIn.pop.sql
+++ b/schema/750$alert.queueIn.pop.sql
@@ -4,12 +4,19 @@ AS
 BEGIN TRY
     DECLARE @statusQueued int = (Select id FROM [alert].[status] WHERE [name] = 'QUEUED')
     DECLARE @statusProcessing int = (Select id FROM [alert].[status] WHERE [name] = 'PROCESSING')
+    
+    IF OBJECT_ID('tempdb..#messageIn') IS NOT NULL
+        DROP TABLE #messageIn
+
+    CREATE TABLE #messageIn(id BIGINT, port VARCHAR(255), channel VARCHAR(100), sender VARCHAR(255), content VARCHAR(MAX))
+    
 
     SELECT 'messages' resultSetName;
 
     UPDATE m
     SET [statusId] =  @statusProcessing
     OUTPUT INSERTED.id, INSERTED.port, INSERTED.channel, INSERTED.sender, INSERTED.content
+    INTO #messageIn ()
     FROM
     (
         SELECT TOP 1 [id]
@@ -18,6 +25,12 @@ BEGIN TRY
         ORDER BY m.[priority] DESC
     ) s
     JOIN [alert].[messageIn] m on s.Id = m.id
+    
+    SELECT id, port, channel, sender, content
+    FROM #messageIn
+
+    DROP TABLE #messageIn
+    
 END TRY
 BEGIN CATCH
     EXEC core.error

--- a/schema/750$alert.queueOut.pop.sql
+++ b/schema/750$alert.queueOut.pop.sql
@@ -17,7 +17,7 @@ BEGIN TRY
     UPDATE m
     SET [statusId] =  @statusProcessing
     OUTPUT INSERTED.id, INSERTED.port, INSERTED.channel, INSERTED.recipient, INSERTED.content
-    INTO #messageOut
+    INTO #messageOut (id, port, channel, recipient, content)
     FROM
     (
         SELECT TOP (@count) [id]


### PR DESCRIPTION
Now we have this error:
Error: The target table 'm' of the DML statement cannot have any enabled triggers if the statement contains an OUTPUT clause without INTO clause.